### PR TITLE
disable RCurl:::mapUnicodeEscapes to get contents as-is

### DIFF
--- a/R/ROauth.R
+++ b/R/ROauth.R
@@ -97,6 +97,19 @@ setRefClass("OAuth",
                                    GET = oauthGET,
                                    stop("method must be POST or GET"))
 
+                ## RCurl converts `\\` to `\` if the content includes strings like `\u0`
+                ## and for example, response JSON is broken as a result,
+                ## so change RCurl:::mapUnicodeEscapes temporarily to avoid it
+                ## cf. https://github.com/omegahat/RCurl/issues/1
+                rcurlEnv <- getNamespace("RCurl")
+                mapUnicodeEscapes <- get("mapUnicodeEscapes", rcurlEnv)
+                unlockBinding("mapUnicodeEscapes", rcurlEnv)
+                assign("mapUnicodeEscapes", function(str) str, rcurlEnv)
+                on.exit({
+                  assign("mapUnicodeEscapes", mapUnicodeEscapes, rcurlEnv)
+                  lockBinding("mapUnicodeEscapes", rcurlEnv)
+                }, add = TRUE)
+
                 httpFunc(URLencode(URL), params=params, consumerKey=.self$consumerKey,
                          consumerSecret=.self$consumerSecret,
                          oauthKey=.self$oauthKey, oauthSecret=.self$oauthSecret,


### PR DESCRIPTION
This change is a workaround for https://github.com/omegahat/RCurl/issues/1.

OAuth#OAuthRequest shouldn't change the response body.
Here is a sample code to explain this issue.

```
> twitteR:::twInterfaceObj$doAPICall(url="http://abicky.net/hatena/rcurl/a.json")
Error in twFromJSON(out) : 
  Error: Malformed response from server, was not JSON.
The most likely cause of this error is Twitter returning a character which
can't be properly parsed by R. Generally the only remedy is to wait long
enough for the offending character to disappear from searches (e.g. if
using searchTwitter()).
```

The response JSON is broken because OAuth#OAuthRequest change the JSON in this sample.

After applying this change, twitteR:::twInterfaceObj works correctly.

```
> twitteR:::twInterfaceObj$doAPICall(url="http://abicky.net/hatena/rcurl/a.json")
$a
[1] "\\\"0\\\""
```
