### PR TITLE
add `normalizeParams` function

### DIFF
--- a/R/ROauth.R
+++ b/R/ROauth.R
@@ -140,14 +140,14 @@ oauthPOST <- function(url, consumerKey, consumerSecret,
   if(is.null(curl))
     curl <- getCurlHandle()
   
-  auth <- signRequest(url, params, consumerKey, consumerSecret,
+  params <- signRequest(url, params, consumerKey, consumerSecret,
                       oauthKey=oauthKey, oauthSecret=oauthSecret,
                       httpMethod="POST", signMethod=signMethod,
                       handshakeComplete=handshakeComplete)
   opts <- list(...)
   
   ## post ,specify the method
-  postForm(url, .params = c(params, lapply(auth, I)), curl = curl,
+  postForm(url, .params = params, curl = curl,
            .opts = opts, style = "POST")
 }
 
@@ -161,10 +161,9 @@ oauthGET <- function(url, consumerKey, consumerSecret,
   if(is.null(curl))
     curl <- getCurlHandle()
    
-   auth <- signRequest(url, params, consumerKey, consumerSecret,
+   params <- signRequest(url, params, consumerKey, consumerSecret,
                        oauthKey=oauthKey, oauthSecret=oauthSecret,
                        httpMethod="GET", signMethod=signMethod)
 
-   params <- c(params, as.list(auth))
    getForm(url, .params = params, curl = curl, .opts = c(httpget = TRUE,  list(...)))
 }

--- a/R/sign.R
+++ b/R/sign.R
@@ -25,7 +25,7 @@ signRequest  <- function(url, params, consumerKey, consumerSecret,
                                              )
   params["oauth_version"] <- '1.0'
 
-  args <- normalizeParams(params, escapeFun)
+  args <- escapeFun(normalizeParams(params, escapeFun), post.amp = TRUE)
 
   if(is.null(oauthSecret))
      oauthSecret <- ""
@@ -125,5 +125,5 @@ normalizeParams <- function(params, escapeFun) {
   params <- sapply(params, escapeFun, post.amp = TRUE)
   ## If two or more parameters share the same name, they are sorted by their value.
   params <- params[order(names(params), params)]
-  return(escapeFun(paste(names(params), params, sep = "=", collapse = "&"), post.amp = TRUE))
+  return(paste(names(params), params, sep = "=", collapse = "&"))
 }


### PR DESCRIPTION
Currently, there are some issues in signRequest as below:
1. the keys of parameters are not encoded
2. sort parameters before encoding parameters
3. sort by only keys
4. parameters whose name begins with 'oauth_' can be duplicated

I think this change resolves these issues.
